### PR TITLE
General Improvements + Bugfix

### DIFF
--- a/MSD/MSD.cpp
+++ b/MSD/MSD.cpp
@@ -142,16 +142,19 @@ int main(int argc, char* argv[])
 	switch (argc)
 	{
 	case 1:
+		std::cout << "Missing path to Miles data folder! Correct Syntax is MSD <path to data> [args]." << std::endl;
+		std::cout << "Example with executable in Apex Legends root: MSD ./audio/ship [args]" << std::endl;
+	case 2:
 		RECORDING_SESSION = false;
 		break;
-	case 2:
-		if (strcmp(argv[1], "-l") == 0)
+	case 3:
+		if (strcmp(argv[2], "-l") == 0)
 		{
 			EXPORT_EVENT_NAMES = true;
 		}
 		else
 		{
-			if (!cstrIsDigits(argv[1]))
+			if (!cstrIsDigits(argv[2]))
 			{
 				std::cout << "Event ID passed contained invalid characters" << std::endl;
 				PrintHelp();
@@ -161,20 +164,20 @@ int main(int argc, char* argv[])
 			RECORDING_SESSION = true;
 		}
 		break;
-	case 3: 
-		if (!cstrIsDigits(argv[1]))
+	case 4: 
+		if (!cstrIsDigits(argv[2]))
 		{
 			std::cout << "First event ID passed contained invalid characters" << std::endl;
 			PrintHelp();
 			return 1;
 		}
-		if (!cstrIsDigits(argv[2]))
+		if (!cstrIsDigits(argv[3]))
 		{
 			std::cout << "Second event ID passed contained invalid characters" << std::endl;
 			PrintHelp();
 			return 1;
 		}
-		for (int i = atoi(argv[1]); i <= atoi(argv[2]); i++) {
+		for (int i = atoi(argv[2]); i <= atoi(argv[3]); i++) {
 			queuedEvents.push_back(i);
 		}
 		RECORDING_SESSION = true;
@@ -183,13 +186,15 @@ int main(int argc, char* argv[])
 		PrintHelp();
 		return 1;
 	}
-	if (!std::filesystem::exists(std::filesystem::path("./audio/ship/")))
+	if (!std::filesystem::exists(std::filesystem::path(argv[1])))
 	{
-		std::cout << "Couldn't find ./audio/ship/ folder. Is MSD inside the Apex Legends folder?" << std::endl;
+		std::cout << "Couldn't find target folder. Did you enter the path correctly? ";
+		std::cout << "If you're entering an abbreviated path ensure that you're specifying folder root. ";
+		std::cout << "Example path from top level game directory to data would be ./audio/ship" << std::endl;
 		return 1;
 	}
 
-	Project project = SetupMiles(&logM, EXPORT_EVENT_NAMES);
+	Project project = SetupMiles(&logM, argv[1], EXPORT_EVENT_NAMES);
 	recorder = new Recorder(project.bank);
 
 	events = MilesBankGetEventCount(project.bank);

--- a/MSD/Miles.cpp
+++ b/MSD/Miles.cpp
@@ -129,14 +129,14 @@ Project SetupMiles(void (WINAPI* callback)(int, char*), std::string dir_path, bo
 	std::string localized;
 	GetMatchingFile(std::regex("general\\.mbnk$"), &mbnk, dir_path);
 	GetMatchingFile(std::regex("general_stream\\.mstr"), &general, dir_path);
-	GetMatchingFile(std::regex("general_\\w*\\.mstr"), &localized, dir_path);
+	GetMatchingFile(std::regex("general_((?!stream)\\w)*\\.mstr"), &localized, dir_path);
 	project.bank = MilesBankLoad(project.driver, mbnk.c_str(), general.c_str(), localized.c_str(), 0);
 
 	if (IsPatched(dir_path)) {
 		std::string general_patch;
 		std::string localized_patch;
 		GetMatchingFile(std::regex("general_stream_patch_\\d\\.mstr"), &general_patch, dir_path);
-		GetMatchingFile(std::regex("general_\\w*_patch_\\d\\.mstr"), &localized_patch, dir_path);
+		GetMatchingFile(std::regex("general_((?!stream)\\w)*\\_patch_\\d\\.mstr"), &localized_patch, dir_path);
 		MilesBankPatch(project.bank, general_patch.c_str(), localized_patch.c_str());
 	}
 

--- a/MSD/Miles.cpp
+++ b/MSD/Miles.cpp
@@ -26,9 +26,9 @@ std::vector<std::string> GetEventNames(Bank bank)
 	return collectedNames;
 }
 
-bool GetMatchingFile(std::regex reg, std::string* out)
+bool GetMatchingFile(std::regex reg, std::string* out, std::string dir_path)
 {
-	for (const auto& entry : fs::directory_iterator(fs::path("./audio/ship/")))
+	for (const auto& entry : fs::directory_iterator(fs::path(dir_path)))
 	{
 		if (std::regex_search(entry.path().string(), reg))
 		{
@@ -42,10 +42,10 @@ bool GetMatchingFile(std::regex reg, std::string* out)
 	return false;
 }
 
-bool GetLocalizedLanguage(std::string* out)
+bool GetLocalizedLanguage(std::string* out, std::string dir_path)
 {
 	auto reg = std::regex("general_(\\w*).mstr");
-	for (const auto& entry : fs::directory_iterator(fs::path("./audio/ship/")))
+	for (const auto& entry : fs::directory_iterator(fs::path(dir_path)))
 	{
 		std::smatch languageMatch;
 		std::string path = entry.path().string();
@@ -58,13 +58,13 @@ bool GetLocalizedLanguage(std::string* out)
 	return false;
 }
 
-bool IsPatched()
+bool IsPatched(std::string dir_path)
 {
-	return GetMatchingFile(std::regex("_patch_"), 0);
+	return GetMatchingFile(std::regex("_patch_"), 0, dir_path);
 }
 
 
-Project SetupMiles(void (WINAPI* callback)(int, char*), bool silent)
+Project SetupMiles(void (WINAPI* callback)(int, char*), std::string dir_path, bool silent)
 { 
 	Project project;
 	int startup_parameters = 0;
@@ -94,10 +94,24 @@ Project SetupMiles(void (WINAPI* callback)(int, char*), bool silent)
 
 	std::string mprj;
 	std::string language;
-	GetMatchingFile(std::regex("audio.mprj$"), &mprj);
-	GetLocalizedLanguage(&language);
+	GetMatchingFile(std::regex(".mprj$"), &mprj, dir_path);
+	GetLocalizedLanguage(&language, dir_path);
 
-	MilesProjectLoad(project.driver, mprj.c_str(), language.c_str(), "audio");
+	std::string project_name = mprj;
+
+	//Extract project name from .mprj path. Sourced from https://stackoverflow.com/questions/8520560/get-a-file-name-from-a-path
+	const size_t last_slash_idx = project_name.find_last_of("\\/");
+	if (std::string::npos != last_slash_idx)
+	{
+		project_name.erase(0, last_slash_idx + 1);
+	}
+	const size_t period_idx = project_name.rfind('.');
+	if (std::string::npos != period_idx)
+	{
+		project_name.erase(period_idx);
+	}
+
+	MilesProjectLoad(project.driver, mprj.c_str(), language.c_str(), project_name.c_str());
 
 	__int64 status = MilesProjectGetStatus(project.driver);
 	while (status == 0) {
@@ -113,16 +127,16 @@ Project SetupMiles(void (WINAPI* callback)(int, char*), bool silent)
 	std::string mbnk;
 	std::string general;
 	std::string localized;
-	GetMatchingFile(std::regex("general\\.mbnk$"), &mbnk);
-	GetMatchingFile(std::regex("general_stream\\.mstr"), &general);
-	GetMatchingFile(std::regex("general_\\w*\\.mstr"), &localized);
+	GetMatchingFile(std::regex("general\\.mbnk$"), &mbnk, dir_path);
+	GetMatchingFile(std::regex("general_stream\\.mstr"), &general, dir_path);
+	GetMatchingFile(std::regex("general_\\w*\\.mstr"), &localized, dir_path);
 	project.bank = MilesBankLoad(project.driver, mbnk.c_str(), general.c_str(), localized.c_str(), 0);
 
-	if (IsPatched()) {
+	if (IsPatched(dir_path)) {
 		std::string general_patch;
 		std::string localized_patch;
-		GetMatchingFile(std::regex("general_stream_patch_\\d\\.mstr"), &general_patch);
-		GetMatchingFile(std::regex("general_\\w*_patch_\\d\\.mstr"), &localized_patch);
+		GetMatchingFile(std::regex("general_stream_patch_\\d\\.mstr"), &general_patch, dir_path);
+		GetMatchingFile(std::regex("general_\\w*_patch_\\d\\.mstr"), &localized_patch, dir_path);
 		MilesBankPatch(project.bank, general_patch.c_str(), localized_patch.c_str());
 	}
 

--- a/MSD/Miles.h
+++ b/MSD/Miles.h
@@ -66,7 +66,7 @@ struct Project {
 
 void SetupBusVolumes(Driver driver);
 std::vector<std::string> GetEventNames(Bank bank);
-Project SetupMiles(void (WINAPI* callback)(int, char*), bool silent);
+Project SetupMiles(void (WINAPI* callback)(int, char*), std::string dir_path, bool silent);
 void StopPlaying(Queue queue);
 
 // Structures

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Miles-10-Sound-Dumper
 Greetings, I've now finished the first beta version of my miles 10 sound dumper. I think I have most bugs ironed out, but obviously please let me know if something is broken. 
 
-In order to use the sound dumper, you'll have to place it inside the Apex Legends folder, right where r5apex.exe is. Then using the command line you can play any sound (as far as I know) and dump them. 
+In order to use the sound dumper, you'll have to place it inside the Apex Legends folder, right where r5apex.exe is. Then using the command line you can play any sound (as far as I know) and dump them. You will have to specify the path to the Miles folder. In the case of Apex Legends, the path from MSD inside the Apex Legends folder to the Miles folder would be .\audio\ship.
+
 ```
 Code:
-MSD                                     -- Open MSD to play sounds
-MSD <EventID>                           -- Dump an event ID
-MSD <EventIDStart> <EventIDEnd>         -- Dump a range of sounds, inclusive
-MSD -l                                  -- Display list of all event IDs and names contained in audio files
+MSD <Path to Miles folder>                                 -- Open MSD to play sounds
+MSD <Path to Miles folder> <EventID>                       -- Dump an event ID
+MSD <Path to Miles folder> <EventIDStart> <EventIDEnd>     -- Dump a range of sounds, inclusive
+MSD <Path to Miles folder> -l                              -- Display list of all event IDs and names contained in audio files
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Miles-10-Sound-Dumper
 Greetings, I've now finished the first beta version of my miles 10 sound dumper. I think I have most bugs ironed out, but obviously please let me know if something is broken. 
 
-In order to use the sound dumper, you'll have to place it inside the Apex Legends folder, right where r5apex.exe is. Then using the command line you can play any sound (as far as I know) and dump them. You will have to specify the path to the Miles folder. In the case of Apex Legends, the path from MSD inside the Apex Legends folder to the Miles folder would be .\audio\ship.
+In order to use the sound dumper, you'll have to place it inside the Apex Legends folder, right where r5apex.exe is. Then using the command line you can play any sound (as far as I know) and dump them. You will have to specify the path to the Miles folder. In the case of Apex Legends, the path from MSD inside the Apex Legends folder to the Miles folder would be 
+
+```
+.\audio\ship
+```
 
 ```
 Code:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ In order to use the sound dumper, you'll have to place it inside the Apex Legend
 .\audio\ship
 ```
 
+The syntax for command line operation is 
+
 ```
 Code:
 MSD <Path to Miles folder>                                 -- Open MSD to play sounds


### PR DESCRIPTION
Developers choose what the project will be called and what path the audio will be stored in (Apex Legends is audio/ship/audio.mprj, Titanfall 2 is r2/sound/titanfall_2.mprj). This removes hard coding of these values.

The regex would match stream before it got to tchinese, for example. Now we explicitly exclude stream banks from the localized search.
